### PR TITLE
chore: Optimize gh workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 jobs:
   build-and-test:
-    uses: Elmeric/my-gha-workflows/.github/workflows/poetry-build-and-test.yml@v1
+    uses: Elmeric/my-gha-workflows/.github/workflows/poetry-build-and-test.yml@dev
     secrets: inherit
     with:
 #      matrix-os-version: "[ 'ubuntu-latest' ]"

--- a/poetry.lock
+++ b/poetry.lock
@@ -994,7 +994,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.2"
-content-hash = "5d5b0add2815f0d97de7739f30d5ff7cd2a8c08a54d5d9ede1b29d56535f2246"
+content-hash = "408670cd4efc883e8c25713e932f634f88debffa2ec470b547db701c774faeb9"
 
 [metadata.files]
 anyio = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ license = "BSD-3-Clause"
 readme = "README.md"
 homepage = "https://github.com/Elmeric/trio-engineio"
 repository = "https://github.com/Elmeric/trio-engineio"
+documentation = "https://elmeric.github.io/trio-engineio"
 packages = [{include = "trio_engineio", from = "src"}]
 classifiers=[
     "Operating System :: OS Independent",
@@ -40,6 +41,9 @@ pre-commit = "^2.20.0"
 invoke = "^1.7.3"
 black = {version = "^22.10.0", extras = ["colorama"]}
 isort = {version = "^5.10.1", extras = ["colors"]}
+
+
+[tool.poetry.group.docs.dependencies]
 mkdocs = "^1.4.2"
 mkdocstrings = {version = "^0.19.0", extras = ["python"]}
 mkdocs-material = {version = "^8.5.10", extras = ["python"]}


### PR DESCRIPTION
Use dev version of the reusable workflow.

Separate docs dependencies in
a dedicated docs group.

[skip ci]